### PR TITLE
Use betterleaks instead of gitleaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
   prek:
     permissions:
       contents: read
-    uses: daniel-mizsak/workflows/.github/workflows/prek.yml@29c63fa152beada07401cef3c08da69178f0bfc7 # v2.2.1
+    uses: daniel-mizsak/workflows/.github/workflows/prek.yml@31499185a34723e78c51d951b98941c07e139780 # v2.3.0
 
   lint:
     permissions:
       contents: read
       pull-requests: write
-    uses: daniel-mizsak/workflows/.github/workflows/lint.yml@29c63fa152beada07401cef3c08da69178f0bfc7 # v2.2.1
+    uses: daniel-mizsak/workflows/.github/workflows/lint.yml@31499185a34723e78c51d951b98941c07e139780 # v2.3.0
     with:
       megalinter-config: "./.github/linters/.megalinter.yml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
 
   # zizmor
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 9257c6050c0261b8c57e712f632dc4a8010109a9 # frozen: v1.25.2
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # frozen: v1.26.1
     hooks:
       - id: zizmor
 
@@ -44,11 +44,11 @@ repos:
       - id: yamllint
         args: [--config-file=.github/linters/.yamllint.yml, --strict]
 
-  # gitleaks
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # frozen: v8.30.1
+  # betterleaks
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: 28f08b4c8c4420a601f67ee9887c201697ff4568 # frozen: v1.6.1
     hooks:
-      - id: gitleaks
+      - id: betterleaks
 
   # codespell
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
- [x] Linting passes
- [x] Tests are added and passing
- [x] Documentation is updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow references to newer pinned reusable workflow versions.
  * Refreshed pre-commit tooling, including a newer security-check hook version.
  * Replaced the existing leak-scanning hook with an updated alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->